### PR TITLE
Fix the spelling of Neovim

### DIFF
--- a/src/components/pages/ExtensionsPage.tsx
+++ b/src/components/pages/ExtensionsPage.tsx
@@ -34,7 +34,7 @@ export const ExtensionsPage = () => {
         logo={<img src={Neovim} height={40} />}
         downloadLink="https://lajp.fi/static/testaustime-nvim"
         sourceCodeLink="https://github.com/lajp/testaustime-nvim"
-        text="Download Testaustime for NeoVim"
+        text="Download Testaustime for Neovim"
       />
     </Group>
   </>;


### PR DESCRIPTION
Neovim is spelled like this.